### PR TITLE
Fix display issue on smaller screen heights

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,6 +8,9 @@
 body {
 	margin: 0;
 	font-family: 'Roboto', sans-serif;
+	min-height: 100vh;
+	display: flex;
+	flex-direction: column;
 }
 
 header, footer {
@@ -17,7 +20,8 @@ header, footer {
 	align-items: center;
 	color: #aa1;
 	background-color: #222;
-	height: 16vh;
+	min-height: 16vh;
+	flex: 1;
 }
 
 header {
@@ -30,13 +34,14 @@ footer {
 
 main {
 	display: flex;
-	height: 535px; /* Fixed to height of canvas + instructions */
+	min-height: 535px; /* height of canvas + instructions */
 	color: #ddd;
 	justify-content: center;
 	background-color: #222;
 	background-image: url('../assets/images/earth-space.jpeg');
 	background-position: center;
 	background-size: cover;
+	flex: 3;
 }
 
 .centerpiece { /* where the game lives */
@@ -51,12 +56,10 @@ aside {
 
 .bezel {
 	width: 20vw;
-	height: 100%;
 	background: #aa1;
 }
 
 .container {
-	height: 100%;
 	padding: 5px 10px;
 	display: flex;
 	flex-direction: column;

--- a/css/style.css
+++ b/css/style.css
@@ -30,13 +30,18 @@ footer {
 
 main {
 	display: flex;
-	height: 68vh;
+	height: 535px; /* Fixed to height of canvas + instructions */
 	color: #ddd;
 	justify-content: center;
 	background-color: #222;
 	background-image: url('../assets/images/earth-space.jpeg');
 	background-position: center;
 	background-size: cover;
+}
+
+.centerpiece { /* where the game lives */
+	display: flex;
+	flex-direction: column;
 }
 
 aside {
@@ -148,11 +153,6 @@ tr :first-child {
 .btn:hover {
 	animation: buttonHover;
 	animation-duration: 1s;
-}
-
-.centerpiece { /* where the game lives */
-	display: flex;
-	flex-direction: column;
 }
 
 .bottom-instructions {

--- a/index.html
+++ b/index.html
@@ -59,6 +59,9 @@
 				<img src="assets/images/space.png" alt="Space bar">
 				<img src="assets/images/dkey.png" alt="A key left">
 			</div>
+			<div class="spacer">
+
+			</div>
 
 		</div>
 

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -58,3 +58,10 @@ function startGame(){
 	// Start the canvas loop
 	loop();
 }
+
+// prevent space from scrolling the page
+window.onkeydown = (e) => {
+	if (e.keyCode == 32){
+		e.preventDefault();
+	}
+};


### PR DESCRIPTION
Sets a minimum pixel height to the `<main>` element. This fixes #2. Now the game displays with correct styling when playing on full screen or a windowed screen.

Also had to prevent the default action for the space bar to keep the page from scrolling down while firing.